### PR TITLE
bugfix: Crash on activity pause

### DIFF
--- a/debug-panel-core/src/main/kotlin/com/redmadrobot/debug_panel_core/util/ApplicationLifecycleHandler.kt
+++ b/debug-panel-core/src/main/kotlin/com/redmadrobot/debug_panel_core/util/ApplicationLifecycleHandler.kt
@@ -47,7 +47,7 @@ internal class ApplicationLifecycleHandler(
                         )
 
                         ContextCompat.registerReceiver(
-                            activity.applicationContext,
+                            activity,
                             debugPanelBroadcastReceiver,
                             filter,
                             ContextCompat.RECEIVER_NOT_EXPORTED


### PR DESCRIPTION
Сейчас DebugPanelBroadcastReceiver регистрируется с application контекстом, а отписывается от activity, что приводит к крашу
`RuntimeException: Unable to pause activity {.MainActivity}: java.lang.IllegalArgumentException: Receiver not registered`